### PR TITLE
replacing json.dumps with flask jsonify helper wrapper

### DIFF
--- a/app/views/v1/bookshots.py
+++ b/app/views/v1/bookshots.py
@@ -1,5 +1,5 @@
 from app import webapp, mysql
-from flask import request  
+from flask import request, jsonify
 from app.models import *
 import json
 
@@ -45,4 +45,4 @@ def getBooks():
                 del(item_objects[i]['genre1'])
                 del(item_objects[i]['genre2'])
                 del(item_objects[i]['genre3'])
-    return json.dumps(item_objects)
+    return jsonify(item_objects)

--- a/app/views/v1/search.py
+++ b/app/views/v1/search.py
@@ -33,7 +33,7 @@ def searchString():
         return Utils.errorResponse(response, 'HTTP_STATUS_CODE_DATA_MISSING')
    
     if ref == 'web':
-        return json.dumps(WebUtils.fetchSearchResults(query, search_type, page))
+        return jsonify(WebUtils.fetchSearchResults(query, search_type, page))
 
     user_info = {'user_id': user_id, 'gcm_id': gcm_id, 'uuid': uuid}
     search = Search(query, user_info, flow)
@@ -59,11 +59,11 @@ def searchString():
 @webapp.route('/getCategories')
 def getCategories():
     categories = Search.getSearchCategoriesForApp()
-    return json.dumps(categories)
+    return jsonify(categories)
 
 @webapp.route('/getCollectionCategory')
 def getCollectionCategory():
-   return json.dumps(Collection.getByCategory())
+   return jsonify(Collection.getByCategory())
 
 @webapp.route('/searchFail', methods=['POST'])
 def searchFail():
@@ -80,11 +80,11 @@ def searchFail():
 
 @webapp.route('/recommended', methods=['GET'])
 def recommended():
-    return json.dumps(Search([]).mostRecommended())
+    return jsonify(Search([]).mostRecommended())
 
 @webapp.route('/mostSearched', methods=['GET'])
 def mostSearched():
-    return json.dumps(Search([]).mostSearched())
+    return jsonify(Search([]).mostSearched())
 
 @webapp.route('/getMultiplePanels')
 def getMultiplePanels():
@@ -94,5 +94,5 @@ def getMultiplePanels():
     panels = []
     for col_id in cursor.fetchall():
         panels.append(Collection(col_id).getObj())
-    return json.dumps(panels)
+    return jsonify(panels)
 

--- a/app/views/v1/user.py
+++ b/app/views/v1/user.py
@@ -203,7 +203,7 @@ def getWishlist():
     response = {'status': 'False'}
     user_id = Utils.getParam(request.args, 'user_id', 'int')
     if user_id:
-        return json.dumps(User.getWishlist(user_id))
+        return jsonify(User.getWishlist(user_id))
     return Utils.errorResponse(response)
 
 @webapp.route('/addToWishlist', methods=['POST'])


### PR DESCRIPTION
Hi there,

We have a free program analysis tool for Python based web projects, called Bento. While we were scanning GitHub projects for issues, your project triggered a warning for using `json.dumps()` instead of flask `jsonify()`.  My sense is that you chose to use `json.dumps()` because `jsonify()` didn't support lists. That issue is fixed now (https://flask.palletsprojects.com/en/1.1.x/changelog/#version-0-11). 

You may also want to look into updating the `async` function in app/decorators.py, since it is a Python keyword starting from 3.7. But I didn't touch it to keep this PR simple.

Bento also flagged the `async` function in app/decorators.py, since it is a Python keyword starting from 3.7. But I didn't touch it to keep this PR simple. If you are interested, feel free download and give Bento a try (https://bento.dev).